### PR TITLE
[FIX] 탭 메뉴 컴포넌트 레이아웃 수정

### DIFF
--- a/trippy-client/src/App.vue
+++ b/trippy-client/src/App.vue
@@ -10,7 +10,7 @@ import BottomNavigationBar from "@/components/layouts/BottomNavigationBar.vue";
       <TopNavigationBar />
 
       <div class="pt-[100px] pb-[90px]">
-        <div class="p-4 flex flex-col items-center">
+        <div class="flex flex-col items-center">
           <RouterView />
         </div>
       </div>

--- a/trippy-client/src/components/common/TabMenu.vue
+++ b/trippy-client/src/components/common/TabMenu.vue
@@ -1,21 +1,23 @@
 <script setup>
-defineProps({
+import { defineProps, defineEmits } from "vue";
+
+const props = defineProps({
   tabs: { type: Array, required: true },
   tab: { type: String, required: false },
 });
 
-defineEmits(["update:tab"]);
+const emit = defineEmits(["update:tab"]);
 </script>
 
 <template>
-  <div class="flex w-full border-b bg-white">
+  <div class="flex w-full bg-white">
     <button
-      v-for="tabItem in tabs"
+      v-for="tabItem in props.tabs"
       :key="tabItem"
-      @click="$emit('update:tab', tabItem)"
+      @click="emit('update:tab', tabItem)"
       :class="[
-        'py-2 text-base font-medium transition-colors flex-1',
-        tab === tabItem ? 'text-blue-500 border-b-2 border-blue-500' : 'text-gray-400',
+        'py-2 button1 transition-colors flex-1',
+        props.tab === tabItem ? 'text-blue-500 border-b border-blue-500' : 'text-gray-400 border-b border-gray-300',
       ]"
     >
       {{ tabItem }}

--- a/trippy-client/src/components/home/ShortCutItems.vue
+++ b/trippy-client/src/components/home/ShortCutItems.vue
@@ -10,7 +10,7 @@ const shortcutItems = [
   {
     icon: "material-symbols:id-card-rounded",
     title: "신분증/여권\n확인하기",
-    to: "/id-cards",
+    to: "/identification",
   },
   {
     icon: "material-symbols:airplane-ticket",

--- a/trippy-client/src/components/home/ShortCutItems.vue
+++ b/trippy-client/src/components/home/ShortCutItems.vue
@@ -10,17 +10,17 @@ const shortcutItems = [
   {
     icon: "material-symbols:id-card-rounded",
     title: "신분증/여권\n확인하기",
-    to: "/identification",
+    to: "/check/identification",
   },
   {
     icon: "material-symbols:airplane-ticket",
     title: "항공권\n확인하기",
-    to: "/tickets",
+    to: "/check/tickets",
   },
   {
     icon: "heroicons:ticket-solid",
     title: "바우처\n확인하기",
-    to: "/bouchers",
+    to: "/check/bouchers",
   },
   {
     icon: "material-symbols:g-translate",

--- a/trippy-client/src/layouts/DefaultLayout.vue
+++ b/trippy-client/src/layouts/DefaultLayout.vue
@@ -1,0 +1,9 @@
+<script setup>
+import { RouterView } from "vue-router";
+</script>
+
+<template>
+  <div class="w-full p-4">
+    <RouterView />
+  </div>
+</template>

--- a/trippy-client/src/layouts/TabViewLayout.vue
+++ b/trippy-client/src/layouts/TabViewLayout.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { ref, watch } from "vue";
+import { useRoute } from "vue-router";
+import TabMenu from "@/components/common/TabMenu.vue";
+
+const route = useRoute();
+const currentTab = ref("");
+
+watch(
+  () => route.meta.tabs,
+  (newTabs) => {
+    if (newTabs && newTabs.length > 0) {
+      currentTab.value = newTabs[0];
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<template>
+  <div class="w-full">
+    <TabMenu
+      v-if="route.meta.tabs"
+      :tabs="route.meta.tabs"
+      v-model:tab="currentTab"
+    />
+
+    <div class="p-4">
+      <RouterView :current-tab="currentTab" />
+    </div>
+  </div>
+</template>

--- a/trippy-client/src/router/groupAccount.js
+++ b/trippy-client/src/router/groupAccount.js
@@ -1,21 +1,21 @@
 export default [
   {
-    path: "/group-account",
+    path: "group-account",
     name: "group-account-intro",
     component: () => import("../views/group-account/GroupAccountCreateIntroView.vue"),
   },
   {
-    path: "/group-account/step1",
+    path: "group-account/step1",
     name: "group-account-step1",
     component: () => import("../views/group-account/GroupAccountAgreementStep1View.vue"),
   },
   {
-    path: "/group-account/step2",
+    path: "group-account/step2",
     name: "group-account-step2",
     component: () => import("../views/group-account/GroupAccountAgreementStep2View.vue"),
   },
   {
-    path: "/group-account/step3",
+    path: "group-account/step3",
     name: "group-account-step3",
     component: () => import("../views/group-account/GroupAccountAgreementStep3View.vue"),
   },

--- a/trippy-client/src/router/index.js
+++ b/trippy-client/src/router/index.js
@@ -88,13 +88,12 @@ const router = createRouter({
           component: IDView,
           meta: { tabs: ["주민등록", "여권"] },
         },
+        {
+          path: "tickets",
+          name: "AirTicket",
+          component: AirTicketView,
+        },
       ],
-    },
-
-    {
-      path: "/tickets",
-      name: "AirTicket",
-      component: AirTicketView,
     },
   ],
 });

--- a/trippy-client/src/router/index.js
+++ b/trippy-client/src/router/index.js
@@ -1,68 +1,101 @@
 import { createRouter, createWebHistory } from "vue-router";
+
+import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import TabViewLayout from "@/layouts/TabViewLayout.vue";
+
 import HomeView from "@/views/HomeView.vue";
 import PaymentView from "@/views/PaymentView.vue";
 import TravelLogsView from "@/views/TravelLogsView.vue";
 import MenuView from "@/views/MenuView.vue";
 import MapView from "@/views/MapView.vue";
+
+import IdCaptureGuideView from "@/views/identification/IdCaptureGuideView.vue";
+import IdRegistrationView from "@/views/identification/IdRegistrationView.vue";
+
+import ExchangeRateListView from "@/views/exchange-rate/ExchangeRateListView.vue";
+import ExchangeCurrencySelectView from "@/views/exchange-currency/ExchangeCurrencySelectView.vue";
+
+import IDView from "@/views/identification/IdView.vue"
 import AirTicketView from "@/views/air-ticket/AirTicketView.vue";
+
 import GroupAccount from "./groupAccount.js";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
+    // DefaultLayout
     {
       path: "/",
-      name: "home",
-      component: HomeView,
+      component: DefaultLayout,
+      children: [
+        {
+          path: "",
+          name: "home",
+          component: HomeView,
+        },
+        {
+          path: "payment",
+          name: "payment",
+          component: PaymentView,
+        },
+        {
+          path: "travel-logs",
+          name: "travel-logs",
+          component: TravelLogsView,
+        },
+        {
+          path: "menu",
+          name: "menu",
+          component: MenuView,
+        },
+        {
+          path: "identification/guide",
+          name: "identification/guide",
+          component: IdCaptureGuideView,
+        },
+        {
+          path: "identification/registration",
+          name: "identification/registration",
+          component: IdRegistrationView,
+        },
+        {
+          path: "exchange-rate",
+          name: "ExchangeRate",
+          component: ExchangeRateListView,
+        },
+        {
+          path: "exchange-currency",
+          name: "ExchangeCurrency",
+          component: ExchangeCurrencySelectView,
+        },
+        {
+          path: "map",
+          name: "map",
+          component: MapView,
+        },
+        ...GroupAccount,
+      ]
     },
+    // TabViewLayout (탭 메뉴 사용하는 뷰)
     {
-      path: "/payment",
-      name: "payment",
-      component: PaymentView,
+      path: "/check",
+      component: TabViewLayout,
+      redirect : "/check/identification",
+      children: [
+        {
+          path: "identification",
+          name: "identification",
+          component: IDView,
+          meta: { tabs: ["주민등록", "여권"] },
+        },
+      ],
     },
-    {
-      path: "/travel-logs",
-      name: "travel-logs",
-      component: TravelLogsView,
-    },
-    {
-      path: "/menu",
-      name: "menu",
-      component: MenuView,
-    },
-    {
-      path: "/identification",
-      name: "identification",
-      component: () => import("@/views/identification/IdView.vue"),
-    },
-    {
-      path: "/identification/guide",
-      name: "/identification/guide",
-      component: () => import("@/views/identification/IdCaptureGuideView.vue"),
-    },
-    {
-      path: "/identification/registration",
-      name: "/identification/registration",
-      component: () => import("@/views/identification/IdRegistrationView.vue"),
-    },
+
     {
       path: "/tickets",
       name: "AirTicket",
       component: AirTicketView,
     },
-    {
-      path: "/exchange-rates",
-      name: "ExchangeRate",
-      component: () => import("../views/exchange-rate/ExchangeRateListView.vue"),
-    },
-    {
-      path: "/exchange-currency",
-      name: "ExchangeCurrency",
-      component: () => import("../views/exchange-currency/ExchangeCurrencySelectView.vue"),
-    },
-    { path: "/map", name: "map", component: MapView },
-
-    ...GroupAccount,
   ],
 });
 

--- a/trippy-client/src/stores/currentTabStore.js
+++ b/trippy-client/src/stores/currentTabStore.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia';
+import { ref } from "vue";
+
+export const useCurrentTabStore = defineStore("counter", () => {
+  const count = ref(0);
+  const doubleCount = computed(() => count.value * 2);
+  function increment() {
+    count.value++;
+  }
+
+  return { count, doubleCount, increment };
+});

--- a/trippy-client/src/views/HomeView.vue
+++ b/trippy-client/src/views/HomeView.vue
@@ -24,7 +24,7 @@ import ExchangeRateItems from "@/components/home/ExchangeRateItems.vue";
     <div class="flex flex-col gap-1">
       <div class="flex justify-between items-center">
         <h2 class="subtitle2">환율 정보</h2>
-        <RouterLink to="/exchange-rates">
+        <RouterLink to="/exchange-rate">
           <div class="text-gray-400 flex items-center gap-1 hover:text-gray-600">
             <span class="caption2">환율 조회</span>
             <Icon icon="material-symbols:arrow-back-ios-rounded" class="w-3 h-3 rotate-180" />

--- a/trippy-client/src/views/identification/IdView.vue
+++ b/trippy-client/src/views/identification/IdView.vue
@@ -1,10 +1,17 @@
 <script setup>
+import { computed, ref, defineProps } from "vue";
+
 import Idcard from "@/assets/Idcard.png";
 import TabMenu from "@/components/common/TabMenu.vue";
 import DefaultProfile from "@/assets/svg/person.svg";
-
 import DefaultQr from "@/assets/default_qr.png";
-import { computed, ref } from "vue";
+
+const props = defineProps({
+  currentTab: {
+    type: String,
+    required: true,
+  },
+});
 
 const isRegistered = ref(true); // 임시로 고정 설정
 const currentTab = ref("주민등록");
@@ -22,9 +29,7 @@ const maskedId = computed(() => {
 
 <template>
   <div class="w-full">
-    <TabMenu :tabs="['주민등록', '여권']" v-model:tab="currentTab" />
-
-    <div v-if="currentTab === '주민등록'">
+    <div v-if="props.currentTab === '주민등록'">
       <!-- ----------------신분증 등록 안 된 경우---------------- -->
       <div
         v-if="!isRegistered"
@@ -132,7 +137,7 @@ const maskedId = computed(() => {
       </div>
     </div>
 
-    <div v-if="currentTab === '여권'">
+    <div v-if="props.currentTab === '여권'">
       <h1>여권</h1>
     </div>
   </div>

--- a/trippy-client/src/views/identification/IdView.vue
+++ b/trippy-client/src/views/identification/IdView.vue
@@ -2,7 +2,6 @@
 import { computed, ref, defineProps } from "vue";
 
 import Idcard from "@/assets/Idcard.png";
-import TabMenu from "@/components/common/TabMenu.vue";
 import DefaultProfile from "@/assets/svg/person.svg";
 import DefaultQr from "@/assets/default_qr.png";
 
@@ -14,7 +13,6 @@ const props = defineProps({
 });
 
 const isRegistered = ref(true); // 임시로 고정 설정
-const currentTab = ref("주민등록");
 const showDetail = ref(false);
 const toggleOn = ref(false);
 


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #42

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
1H / 1.5H

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
### 서비스의 전체 레이아웃을 두 가지로 분리하였습니다.!!!
**1. DefaultLayout**
기존에 사용하던 레이아웃
**2. TabViewLayout**
탭 메뉴를 사용하는 레이아웃
이 레이아웃은 다음의 뷰에서 사용되며, 오른쪽과 같은 url로 라우팅되어있습니다. 확인해주세요!!! (router/index.js 파일도 한번 확인해주세요!!! 라우팅 어떻게 바꼈는지!!)

- 신분증/여권 확인 뷰 : /check/identification
- 항공권 확인 뷰 : /check/tickets
- 바우처 확인 뷰 : /check/bouchers -> 아직 router/index.js에 선언되어 있지 않음. 바우처 확인 뷰 작업하시는 분께서 작업하실 때 추가해주세요!

항공권, 바우처 확인 뷰를 아예 TabViewLayout의 자식으로 넣어둔거라, 아마 Pull 받으시면 자동으로 탭 버튼이 뜰거라 생각합니다!
현재 탭 버튼의 값을 확인하는 로직은 views/identification/IDView.vue 파일을 참고하시면 될 것 같습니다.

해당 코드를 통해 props로 부모 레이아웃에서부터 currentTab 값을 받아옵니다.

```
const props = defineProps({
  currentTab: {
    type: String,
    required: true,
  },
});
```

간단하게 props.currentTab === '이용전' 이런 식으로 값을 확인하시면 될 거 같습니다!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
<img width="377" height="816" alt="image" src="https://github.com/user-attachments/assets/02f97b5d-eff1-4b5f-b4e5-9ccf22bd3f42" />
<img width="379" height="822" alt="image" src="https://github.com/user-attachments/assets/6966c8d9-7cbc-47e1-b63e-7f10d5f9d6d3" />

