### PR TITLE
[FEAT] 계좌 리스트 아이템 컴포넌트화 (#98)

### DIFF
--- a/trippy-client/src/components/account/AccountItem.vue
+++ b/trippy-client/src/components/account/AccountItem.vue
@@ -7,7 +7,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div class="flex items-center justify-between p-4 rounded-xl active:bg-blue-100">
+  <div class="flex w-full items-center justify-between p-4 rounded-xl active:bg-blue-100">
     <div class="flex items-center gap-4">
       <img :src="props.data.logo" class="size-9 bg-gray-100 rounded-full" />
       <div>

--- a/trippy-client/src/components/account/AccountItem.vue
+++ b/trippy-client/src/components/account/AccountItem.vue
@@ -1,0 +1,19 @@
+<script setup>
+import { defineProps } from "vue";
+
+const props = defineProps({
+  data: Object
+});
+</script>
+
+<template>
+  <div class="flex items-center justify-between p-4 rounded-xl active:bg-blue-100">
+    <div class="flex items-center gap-4">
+      <img :src="props.data.logo" class="size-9 bg-gray-100 rounded-full" />
+      <div>
+        <h3 class="subtitle1">{{ props.data.accountType }}</h3>
+        <p class="body1">{{ props.data.bankName }} {{ props.data.accountNumber }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/trippy-client/src/views/exchange-currency/SelectAccountView.vue
+++ b/trippy-client/src/views/exchange-currency/SelectAccountView.vue
@@ -3,6 +3,7 @@ import { bankAccounts } from "@/_dummy/bankAccounts_dummy";
 import { useExchangeStore } from "@/stores/exchangeStore";
 import { storeToRefs } from "pinia";
 import { useRouter } from "vue-router";
+import AccountItem from "@/components/account/AccountItem.vue";
 import NextButton from "@/components/common/NextButton.vue";
 
 const accountStore = useExchangeStore();
@@ -41,14 +42,7 @@ const goToAmountView = () => {
             :key="account.accountNumber"
             @click="handleSelect(account)"
           >
-            <img :src="account.logo" :alt="account.bankName" />
-            <div class="flex-col">
-              <p class="flex gap-4 subtitle2">{{ account.accountType }}</p>
-              <div class="flex gap-2 body2">
-                <p>{{ account.bankName }}</p>
-                <p>{{ account.accountNumber }}</p>
-              </div>
-            </div>
+            <AccountItem :data="account" />
           </li>
         </ul>
       </div>

--- a/trippy-client/src/views/exchange-currency/SelectAccountView.vue
+++ b/trippy-client/src/views/exchange-currency/SelectAccountView.vue
@@ -32,7 +32,7 @@ const goToAmountView = () => {
       </p>
       <p v-else class="title4 text-gray-400">계좌를 선택해 주세요</p>
     </div>
-    <div class="w-full overflow-scroll hide-scrollbar">
+    <ul class="w-full overflow-scroll hide-scrollbar pb-12">
       <h3 class="subtitle1 ml-4 mb-1">내 계좌</h3>
       <li
         class="flex cursor-pointer"
@@ -42,7 +42,7 @@ const goToAmountView = () => {
       >
         <AccountItem :data="account" />
       </li>
-    </div>
+    </ul>
     <div class="fixed bottom-0 left-0 right-0 z-50 w-full max-w-full pt-4 pb-[34px] px-4 bg-white md:max-w-[375px] md:mx-auto">
       <NextButton
         title="다음"

--- a/trippy-client/src/views/exchange-currency/SelectAccountView.vue
+++ b/trippy-client/src/views/exchange-currency/SelectAccountView.vue
@@ -21,34 +21,35 @@ const goToAmountView = () => {
 </script>
 
 <template>
-  <div class="flex h-full flex-col justify-between">
-    <div>
-      <h2 class="font-bold m-10 text-center title2">환전할 계좌를 선택해주세요</h2>
-      <div
+  <div class="flex h-full flex-col justify-between gap-8">
+    <h2 class="text-center title2 mt-8">환전할 계좌를 선택해주세요</h2>
+    <div class="text-center border-b-2 border-gray-300 p-2 w-full">
+      <p
         v-if="selectedAccount"
-        class="text-center border-b-2 border-b-gray-300 p-2 w-[20rem] mx-auto"
+        class="title4"
       >
-        <p class="title4">{{ selectedAccount.bankName }} {{ selectedAccount.accountNumber }}</p>
-      </div>
-      <div v-else class="text-center border-b-2 border-b-gray-300 p-2 w-[20rem] mx-auto">
-        <p class="title4 text-gray-400">계좌를 선택해 주세요</p>
-      </div>
-      <div class="w-auto h-[27rem] overflow-auto hide-scrollbar">
-        <ul class="mx-3">
-          <h3 class="subtitle1 gap-8 mt-5">내 계좌</h3>
-          <li
-            class="flex gap-4 cursor-pointer my-5"
-            v-for="account in bankAccounts"
-            :key="account.accountNumber"
-            @click="handleSelect(account)"
-          >
-            <AccountItem :data="account" />
-          </li>
-        </ul>
-      </div>
+        {{ selectedAccount.bankName }} {{ selectedAccount.accountNumber }}
+      </p>
+      <p v-else class="title4 text-gray-400">계좌를 선택해 주세요</p>
     </div>
-
-    <NextButton title="다음" @click="goToAmountView" :disabled="!selectedAccount"></NextButton>
+    <div class="w-full overflow-scroll hide-scrollbar">
+      <h3 class="subtitle1 ml-4 mb-1">내 계좌</h3>
+      <li
+        class="flex cursor-pointer"
+        v-for="account in bankAccounts"
+        :key="account.accountNumber"
+        @click="handleSelect(account)"
+      >
+        <AccountItem :data="account" />
+      </li>
+    </div>
+    <div class="fixed bottom-0 left-0 right-0 z-50 w-full max-w-full pt-4 pb-[34px] px-4 bg-white md:max-w-[375px] md:mx-auto">
+      <NextButton
+        title="다음"
+        @click="goToAmountView"
+        :disabled="!selectedAccount"
+      />
+    </div>
   </div>
 </template>
 

--- a/trippy-client/src/views/personal-accounts/ImportAccountView.vue
+++ b/trippy-client/src/views/personal-accounts/ImportAccountView.vue
@@ -7,10 +7,10 @@ import SMSCertification from "@/components/personal-accounts/import-accounts/SMS
 import AgreeToTerms from "@/components/personal-accounts/import-accounts/AgreeToTerms.vue";
 import PasswordInput from "@/components/common/inputs/PasswordInput.vue";
 import LoadingView from "@/components/common/loading/LoadingView.vue";
-import ChooseAccounts from "@/components/personal-accounts/import-accounts/SelectAccounts.vue";
+import SelectAccount from "@/components/personal-accounts/import-accounts/SelectAccounts.vue";
 import CompleteImport from "@/components/personal-accounts/import-accounts/CompleteImport.vue";
 
-const views = [Intro, InputForm, SMSCertification, AgreeToTerms, PasswordInput, LoadingView, ChooseAccounts, CompleteImport];
+const views = [Intro, InputForm, SMSCertification, AgreeToTerms, PasswordInput, LoadingView, SelectAccount, CompleteImport];
 const currentIndex = ref(0);
 
 const currentView = computed(() => views[currentIndex.value]);


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #98 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
30M / 15M

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
### 컴포넌트이름
AccountItem.vue

### 위치
src/components/account 디렉토리

### 사용 예시
props로 일단 저 더미데이터 넘겨주시면 됩니다!

```
import { bankAccounts } from "@/_dummy/bankAccounts_dummy.js";
const accountsData = ref(bankAccounts);
```

src/views/exchange-currency/SelectAccountView.vue 이 파일 참고하시면 좋을 것 같습니다!!!
(근데 이 파일에는 피니아 스토어 데이터를 props로 넘겨주고 있습니다... 지금은 그냥 위에 적어둔 더미데이터로 넘겨줘도 괜찮을 것 같습니다.)
<img width="462" height="243" alt="image" src="https://github.com/user-attachments/assets/678dcb1e-d8d7-43af-8013-94e46c8b61d3" />


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
<img width="301" height="611" alt="image" src="https://github.com/user-attachments/assets/1b270782-1d49-4f4f-bce5-b6ba2d581430" />

