### PR TITLE
[FEAT] 환전 기능 비밀번호 뷰 추가

### DIFF
--- a/trippy-client/src/router/index.js
+++ b/trippy-client/src/router/index.js
@@ -118,6 +118,12 @@ const router = createRouter({
           meta: { title: "환전", bgColor: "white" },
         },
         {
+          path: "exchange-currency-password",
+          name: "ExchangeCurrencyPassword",
+          component: () => import("@/views/exchange-currency/PasswordInputView.vue"),
+          meta: { title: "환전", bgColor: "white" },
+        },
+        {
           path: "exchange-currency-finish",
           name: "ExchangeCurrencyFinish",
           component: () => import("@/views/exchange-currency/FinishExchangeView.vue"),

--- a/trippy-client/src/views/exchange-currency/InputAmountView.vue
+++ b/trippy-client/src/views/exchange-currency/InputAmountView.vue
@@ -91,8 +91,8 @@ watch(selectedCurrencyCode, (newCode) => {
 });
 
 const router = useRouter();
-const goToFinishView = () => {
-  router.push("/exchange-currency-finish");
+const goToPasswordView = () => {
+  router.push("/exchange-currency-password");
 };
 </script>
 
@@ -167,7 +167,7 @@ const goToFinishView = () => {
       </div>
     </div>
     <div>
-      <NextButton title="확인" @click="goToFinishView"></NextButton>
+      <NextButton title="확인" @click="goToPasswordView"></NextButton>
     </div>
   </div>
 </template>

--- a/trippy-client/src/views/exchange-currency/PasswordInputView.vue
+++ b/trippy-client/src/views/exchange-currency/PasswordInputView.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { useRouter } from "vue-router";
+import PasswordInput from "@/components/common/inputs/PasswordInput.vue";
+
+const router = useRouter();
+const goToFinishView = () => {
+  router.push("/exchange-currency-finish");
+};
+</script>
+
+<template>
+  <PasswordInput @next="goToFinishView" />
+</template>
+
+<style></style>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #75 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
1일 / 1시간

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->

// 환전 기능 사이에 비밀번호 입력 뷰 추가
소정님께서 만들어주신 비밀번호 컴포넌트를 활용하여 뷰를 만들었습니다. (무한 감사)
환전에 필요한 정보들을 모두 다 입력한 후 비밀번호가 맞았을 때 비로소 환전 완료 정보 뷰가 뜨도록 개발하였습니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->

<img width="368" height="766" alt="스크린샷 2025-07-30 오후 1 34 30" src="https://github.com/user-attachments/assets/722ab5e9-38bb-470a-b20f-d64b37db67be" />
