### PR TITLE
[FEAT] 키패드 컴포넌트 분리 (#113)

### DIFF
--- a/trippy-client/src/components/account/AmountInputScreen.vue
+++ b/trippy-client/src/components/account/AmountInputScreen.vue
@@ -3,6 +3,7 @@ import { defineProps, defineEmits, ref } from "vue";
 import { numberWithCommas } from "@/assets/utils/index.js";
 import AmountInput from "@/components/common/inputs/AmountInput.vue";
 import NextButton from "@/components/common/NextButton.vue";
+import NumberKeypad from "@/components/common/NumberKeypad.vue";
 
 const props = defineProps({
   title: String,
@@ -61,34 +62,10 @@ const onClick = () => {
         @click="onClick"
       />
     </div>
-    <div class="grid grid-cols-3 w-full gap-2">
-      <button
-        v-for="n in 9"
-        :key="n"
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="() => onPressKey(n)"
-      >
-        {{ n }}
-      </button>
-      <button
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="() => onPressKey('00')"
-      >
-        00
-      </button>
-      <button
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="() => onPressKey(0)"
-      >
-        0
-      </button>
-      <button
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="onDelete"
-      >
-        ←
-      </button>
-    </div>
+    <NumberKeypad
+      @press-key="onPressKey"
+      @delete="onDelete"
+      type="amount" />
   </div>
 </template>
 

--- a/trippy-client/src/components/common/NumberKeypad.vue
+++ b/trippy-client/src/components/common/NumberKeypad.vue
@@ -1,0 +1,52 @@
+<script setup>
+const props = defineProps({
+  type: {
+    type: String,
+    required: false,
+    default: "password",
+  }
+});
+
+const emit = defineEmits(["press-key", "delete"]);
+
+const handlePress = (num) => {
+  emit("press-key", num);
+};
+
+const handleDelete = () => {
+  emit("delete");
+};
+</script>
+
+<template>
+  <div class="grid grid-cols-3 w-full gap-2">
+    <button
+      v-for="n in 9"
+      :key="n"
+      class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
+      @click="() => handlePress(n)"
+    >
+      {{ n }}
+    </button>
+    <button
+      v-if="props.type==='amount'"
+      class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
+      @click="() => handlePress('00')"
+    >
+      00
+    </button>
+    <div v-else></div>
+    <button
+      class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
+      @click="() => handlePress(0)"
+    >
+      0
+    </button>
+    <button
+      class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
+      @click="handleDelete"
+    >
+      ←
+    </button>
+  </div>
+</template>

--- a/trippy-client/src/components/common/inputs/PasswordInput.vue
+++ b/trippy-client/src/components/common/inputs/PasswordInput.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, defineEmits, defineProps } from "vue";
 import NextButton from "@/components/common/NextButton.vue";
+import NumberKeypad from "@/components/common/NumberKeypad.vue";
 import AlertModal from "@/components/common/modals/AlertModal.vue";
 
 const props = defineProps({
@@ -57,6 +58,7 @@ const handleClick = () => {
         class="caption2 text-blue-400 underline"
       >혹시 비밀번호를 잊으셨나요?</a>
     </div>
+
     <div class="mx-[-1rem] mb-2">
       <NextButton
         title="입력 완료"
@@ -65,29 +67,12 @@ const handleClick = () => {
         @click="handleClick"
       />
     </div>
-    <div class="grid grid-cols-3 w-full gap-2">
-      <button
-        v-for="n in 9"
-        :key="n"
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="() => onPressKey(n)"
-      >
-        {{ n }}
-      </button>
-      <div></div>
-      <button
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="() => onPressKey(0)"
-      >
-        0
-      </button>
-      <button
-        class="h-12 title2 font-normal rounded-lg active:bg-blue-100"
-        @click="onDelete"
-      >
-        ←
-      </button>
-    </div>
+
+    <NumberKeypad
+      @press-key="onPressKey"
+      @delete="onDelete"
+    />
+
     <AlertModal
       v-model="isModalOpen"
       title="비밀번호가 틀렸습니다."


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #113

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
1H / 1H

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
### 컴포넌트 위치
src/components/common/NumberKeypad.vue

### 사용법
1. NumberKeypad 컴포넌트를 가져옵니다.
`import NumberKeypad from "@/components/common/NumberKeypad.vue";`

2. 아래 코드처럼 컴포넌트에 props를 전달합니다.

```
<div class="mx-[-1rem] mb-2">
      <NextButton
        :title="'요청하기'"
        :disabled="!amount"
        :isRounded="false"
        @click="onClick"
      />
</div>
<NumberKeypad
      @press-key="onPressKey"
      @delete="onDelete"
      type="amount"
/>
```

금액을 입력하는 부분에서는 NumberKeypad에 type으로 "amount"를 보내주어야 합니다!

아래는 이벤트 함수 설명과 예시 코드입니다.
- onPressKey 함수: 키패드 입력시 금액 변수에 문자열을 붙입니다.
- onDelete 함수: 화살표 부분 클릭시 금액 변수의 뒷자리부터 잘라냅니다.

```
const amount = ref(""); // input 창에 표시할 사용자가 입력하는 금액

const onPressKey = (num) => {
  if (amount.value.length >= 10) return;

  if (amount.value === "0") {
    amount.value = String(num);
  } else {
    amount.value += String(num);
  }

  console.log(amount.value);
};

const onDelete = () => {
  if (!amount.value) return;
  amount.value = amount.value.slice(0, -1);
};
```
## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
- 금액 입력 키패드로 사용하고 싶다 -> src/components/account/AmountInputScreen.vue 코드 참고
- 비밀번호 입력 키패드로 사용하고 싶다 -> src/components/common/PasswordInput.vue 코드 참고