### PR TITLE
[FEAT] 모임계좌 카카오톡 초대 링크 생성 API 연동 (#137)

### DIFF
--- a/trippy-client/src/api/groupAccount.js
+++ b/trippy-client/src/api/groupAccount.js
@@ -6,7 +6,7 @@ const BASE_URL = "/group-account";
 const userId = ref(1);
 
 export default {
-  async CreateAccounId(accountName, email, mainAccountId) {
+  async createAccounId(accountName, email, mainAccountId) {
     const res = await api.post(`${BASE_URL}/create?userId=${userId.value}`, {
       accountName,
       email,

--- a/trippy-client/src/api/groupAccount.js
+++ b/trippy-client/src/api/groupAccount.js
@@ -16,7 +16,7 @@ export default {
   },
 
   async createURL(accountId, accountName) {
-    const res = await api.post(`${BASE_URL}/invite/reissue=${userId.value}`, {
+    const res = await api.post(`${BASE_URL}/invite/reissue?userId=${userId.value}`, {
       accountId,
       accountName,
     });

--- a/trippy-client/src/api/groupAccount.js
+++ b/trippy-client/src/api/groupAccount.js
@@ -14,4 +14,12 @@ export default {
     });
     return res.data.data;
   },
+
+  async createURL(accountId, accountName) {
+    const res = await api.post(`${BASE_URL}/invite/reissue=${userId.value}`, {
+      accountId,
+      accountName,
+    });
+    return res.data.data;
+  },
 };

--- a/trippy-client/src/api/index.js
+++ b/trippy-client/src/api/index.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const instance = axios.create({
-  baseURL: "http://172.30.1.66:8080/",
+  baseURL: "http://localhost:8080/",
   timeout: 10000,
   headers: {
     "Content-Type": "application/json",

--- a/trippy-client/src/api/index.js
+++ b/trippy-client/src/api/index.js
@@ -1,23 +1,23 @@
-import axios from 'axios';
+import axios from "axios";
 
 const instance = axios.create({
-  baseURL: 'http://localhost:8080/',
+  baseURL: "http://172.30.1.66:8080/",
   timeout: 10000,
   headers: {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   },
 });
 
 // 요청 인터셉터: 헤더 토큰 추가
 instance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('accessToken');
+    const token = localStorage.getItem("accessToken");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
-  (error) => Promise.reject(error)
+  (error) => Promise.reject(error),
 );
 
 // 응답 인터셉터: 공통 에러 처리
@@ -25,10 +25,10 @@ instance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response && error.response.status === 401) {
-      console.warn('인증 오류 발생');
+      console.warn("인증 오류 발생");
     }
     return Promise.reject(error);
-  }
+  },
 );
 
 export default instance;

--- a/trippy-client/src/main.js
+++ b/trippy-client/src/main.js
@@ -8,7 +8,6 @@ import router from "./router";
 
 const app = createApp(App);
 
-console.log("✅ KAKAO KEY:", import.meta.env.VITE_KAKAO_JS_KEY);
 Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
 
 app.use(createPinia());

--- a/trippy-client/src/stores/groupAccountJoinStore.js
+++ b/trippy-client/src/stores/groupAccountJoinStore.js
@@ -40,10 +40,8 @@ export const useGroupJoinStore = defineStore("groupJoin", () => {
     loading.value = true;
     error.value = null;
     try {
-      console.log("요청 전송 시작");
       const response = await api.createURL(accountId, accountName);
       inviteLink.value = response.inviteTokenURL;
-      console.log("inviteLink.value: ", inviteLink.value);
     } catch (err) {
       error.value = err;
     } finally {

--- a/trippy-client/src/stores/groupAccountJoinStore.js
+++ b/trippy-client/src/stores/groupAccountJoinStore.js
@@ -1,5 +1,6 @@
 import { ref } from "vue";
 import { defineStore } from "pinia";
+import api from "@/api/groupAccount";
 
 export const useGroupJoinStore = defineStore("groupJoin", () => {
   const loading = ref(false);
@@ -33,40 +34,37 @@ export const useGroupJoinStore = defineStore("groupJoin", () => {
   };
 
   //초대 링크 주소: 나중에 배 포완료되고 백에서 토큰 만들어서 가져와서 주소 만들기
-  const inviteLink = "http://10.10.0.22:5173/?token=test123";
+  const inviteLink = ref("");
 
-  const createURL = async () => {
+  const createURL = async (accountId, accountName) => {
     loading.value = true;
     error.value = null;
     try {
-      const response = await api.CreateAccounId(
-        groupAccountName.value,
-        email.value,
-        representativeAccount.value,
-      );
-      createdAccountData.value = response;
+      console.log("요청 전송 시작");
+      const response = await api.createURL(accountId, accountName);
+      inviteLink.value = response.inviteTokenURL;
+      console.log("inviteLink.value: ", inviteLink.value);
     } catch (err) {
       error.value = err;
     } finally {
       loading.value = false;
     }
   };
-
   //초대 보내는 내용
-  const shareToKakao = () => {
+  const shareToKakao = (accountName) => {
     window.Kakao.Link.sendDefault({
       objectType: "text",
-      text: "Trippy에서 모임통장을 만들었어요!",
+      text: `${accountName}에서 모임통장을 만들었어요!`,
       link: {
-        webUrl: inviteLink,
-        mobileWebUrl: inviteLink,
+        webUrl: inviteLink.value,
+        mobileWebUrl: inviteLink.value,
       },
       buttons: [
         {
           title: "지금 참여하기",
           link: {
-            webUrl: inviteLink,
-            mobileWebUrl: inviteLink,
+            webUrl: inviteLink.value,
+            mobileWebUrl: inviteLink.value,
           },
         },
       ],
@@ -88,5 +86,6 @@ export const useGroupJoinStore = defineStore("groupJoin", () => {
     shareToKakao,
     setInviteInfo,
     setRepresentativeAccount,
+    createURL,
   };
 });

--- a/trippy-client/src/stores/groupAccountJoinStore.js
+++ b/trippy-client/src/stores/groupAccountJoinStore.js
@@ -2,6 +2,9 @@ import { ref } from "vue";
 import { defineStore } from "pinia";
 
 export const useGroupJoinStore = defineStore("groupJoin", () => {
+  const loading = ref(false);
+  const error = ref(null);
+
   const userId = ref("");
   //모임통장 계좌
   const groupAccountNumber = ref("");
@@ -32,6 +35,23 @@ export const useGroupJoinStore = defineStore("groupJoin", () => {
   //초대 링크 주소: 나중에 배 포완료되고 백에서 토큰 만들어서 가져와서 주소 만들기
   const inviteLink = "http://10.10.0.22:5173/?token=test123";
 
+  const createURL = async () => {
+    loading.value = true;
+    error.value = null;
+    try {
+      const response = await api.CreateAccounId(
+        groupAccountName.value,
+        email.value,
+        representativeAccount.value,
+      );
+      createdAccountData.value = response;
+    } catch (err) {
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+  };
+
   //초대 보내는 내용
   const shareToKakao = () => {
     window.Kakao.Link.sendDefault({
@@ -54,6 +74,8 @@ export const useGroupJoinStore = defineStore("groupJoin", () => {
   };
 
   return {
+    loading,
+    error,
     userId,
     groupAccountNumber,
     representativeAccount,

--- a/trippy-client/src/stores/groupAccountStore.js
+++ b/trippy-client/src/stores/groupAccountStore.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import api from "@/api/group-account";
+import api from "@/api/groupAccount";
 import { ref } from "vue";
 
 export const useGroupAccountStore = defineStore("groupAccount", () => {

--- a/trippy-client/src/views/group-account/create-account/CreateCompleteView.vue
+++ b/trippy-client/src/views/group-account/create-account/CreateCompleteView.vue
@@ -16,8 +16,9 @@ const accountName = ref("");
 const accountId = ref("");
 const createdAt = ref("");
 
-const shareToKakao = () => {
-  groupJoinStore.shareToKakao();
+const shareToKakao = async () => {
+  await groupJoinStore.createURL(accountId.value, accountName.value);
+  groupJoinStore.shareToKakao(accountName.value);
 };
 
 onMounted(() => {


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #137

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
예상 작업기간 3시간
실제 작업시간 40분


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
- 카카오톡 초대 버튼 클릭 시, 백엔드 API를 호출하여 초대 URL을 생성하고, 해당 URL을 통해 초대를 보낼 수 있도록 구현했습니다.



## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
- 만약 테스트 하실 분들이 있으시다면 백엔드 InviteService 에  BASE_URL을 현재 연결되어 있는 네트워크 IP로 변경하시면 됩니다
- 현재는 계좌 개설시에만 연결 해 두었고 모임 계좌 상세 내역 API연동할 때 나머지도 연결할 예정입니다

<table>
<tr>
<td>
<img width="1284" height="855" alt="image" src="https://github.com/user-attachments/assets/628673d3-42c7-4084-a1e8-b9f7b0da9244" />
</td>
</tr>
</table>
