### PR TITLE
[FEAT] 계좌 목록 (계좌 목록 뷰) API 연동(#149)

### DIFF
--- a/trippy-client/src/api/account.js
+++ b/trippy-client/src/api/account.js
@@ -1,0 +1,13 @@
+import api from "@/api";
+import { ref } from "vue";
+
+const BASE_URL = "/accounts";
+
+const userId = ref(1);
+
+export default {
+  async getPersonalAccountList() {
+    const res = await api.get(`${BASE_URL}?userId=${userId.value}`);
+    return res.data.data;
+  },
+};

--- a/trippy-client/src/api/groupAccount.js
+++ b/trippy-client/src/api/groupAccount.js
@@ -22,4 +22,9 @@ export default {
     });
     return res.data.data;
   },
+
+  async getGroupAccountList() {
+    const res = await api.get(`${BASE_URL}/list?userId=${userId.value}`);
+    return res.data.data;
+  },
 };

--- a/trippy-client/src/stores/accountStore.js
+++ b/trippy-client/src/stores/accountStore.js
@@ -1,22 +1,23 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import accountsSample from "@/_dummy/accounts_sample.json";
+import api from "@/api/account";
 
 export const useAccountStore = defineStore("Account", () => {
-  const accountList = ref([]);
+  const loading = ref(false);
+  const error = ref(null);
+  const personalAccountList = ref([]);
 
-  const filterAccountList = ref([]);
-
-  const GetAccountList = async () => {
-    accountList.value = accountsSample;
-  };
-
-  const FilterAccount = (showGroupAccount) => {
-    if (showGroupAccount) {
-      filterAccountList.value = accountList.value.filter((account) => account.type === "group");
-    } else {
-      filterAccountList.value = accountList.value.filter((account) => account.type === "personal");
+  const getParsonalAccountList = async () => {
+    loading.value = true;
+    error.value = null;
+    try {
+      const response = await api.getPersonalAccountList();
+      personalAccountList.value = response;
+    } catch (err) {
+      error.value = err;
+    } finally {
+      loading.value = false;
     }
   };
-  return { accountList, filterAccountList, GetAccountList, FilterAccount };
+  return { personalAccountList, getParsonalAccountList };
 });

--- a/trippy-client/src/stores/groupAccountStore.js
+++ b/trippy-client/src/stores/groupAccountStore.js
@@ -15,6 +15,9 @@ export const useGroupAccountStore = defineStore("groupAccount", () => {
   //모임주 대표계좌 은행
   const representativeAccountBank = ref("");
 
+  //모임 계좌 리스트
+  const groupAccountList = ref([]);
+
   const createdAccountData = ref({
     accountName: "",
     accountId: "",
@@ -51,6 +54,19 @@ export const useGroupAccountStore = defineStore("groupAccount", () => {
     }
   };
 
+  const getGroupAccountList = async () => {
+    loading.value = true;
+    error.value = null;
+    try {
+      const response = await api.getGroupAccountList();
+      groupAccountList.value = response;
+    } catch (err) {
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+  };
+
   return {
     loading,
     error,
@@ -60,9 +76,11 @@ export const useGroupAccountStore = defineStore("groupAccount", () => {
     representativeAccount,
     representativeAccountBank,
     createdAccountData,
+    groupAccountList,
     emailSet,
     setGroupAccountInfo,
     setRepresentativeAccount,
     createGroupAccount,
+    getGroupAccountList,
   };
 });

--- a/trippy-client/src/views/AccountListview.vue
+++ b/trippy-client/src/views/AccountListview.vue
@@ -28,7 +28,11 @@ onMounted(async () => {
 });
 
 // 토글 변화에 따라 계좌 목록 상단으로 이동 + 필터 적용
-watch(showGroupAccount, async () => {
+watch(showGroupAccount, async (isOn) => {
+  if (isOn && groupAccountList.value.length === 0) {
+    await groupAccountStore.getGroupAccountList();
+    groupAccountList.value = groupAccountStore.groupAccountList;
+  }
   await nextTick();
   if (scrollContainer.value) {
     scrollContainer.value.scrollTop = 0;

--- a/trippy-client/src/views/AccountListview.vue
+++ b/trippy-client/src/views/AccountListview.vue
@@ -28,11 +28,7 @@ onMounted(async () => {
 });
 
 // 토글 변화에 따라 계좌 목록 상단으로 이동 + 필터 적용
-watch(showGroupAccount, async (isOn) => {
-  if (isOn && groupAccountList.value.length === 0) {
-    await groupAccountStore.getGroupAccountList();
-    groupAccountList.value = groupAccountStore.groupAccountList;
-  }
+watch(showGroupAccount, async () => {
   await nextTick();
   if (scrollContainer.value) {
     scrollContainer.value.scrollTop = 0;

--- a/trippy-client/src/views/AccountListview.vue
+++ b/trippy-client/src/views/AccountListview.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { onMounted, ref, watch, nextTick, computed } from "vue";
+import { onMounted, ref, watch, nextTick } from "vue";
 import { useAccountStore } from "@/stores/accountStore";
+import { useGroupAccountStore } from "@/stores/groupAccountStore";
 import router from "@/router";
 import { Icon } from "@iconify/vue";
 import UnifiedAccountCard from "@/components/account/UnifiedAccountCard.vue";
@@ -9,19 +10,25 @@ import QuickAddButton from "@/components/common/buttons/QuickAddButton.vue";
 import AccountIcon from "@/assets/svg/account-icon.svg";
 
 const accountStore = useAccountStore();
+const groupAccountStore = useGroupAccountStore();
 const showGroupAccount = ref(false);
 const scrollContainer = ref(null);
 
-const accountList = computed(() => accountStore.filterAccountList);
+const groupAccountList = ref([]);
+const accountList = ref([]);
 
 onMounted(async () => {
-  await accountStore.GetAccountList();
-  accountStore.FilterAccount(showGroupAccount.value);
+  await accountStore.getParsonalAccountList();
+  await groupAccountStore.getGroupAccountList();
+
+  accountList.value = accountStore.personalAccountList.filter(
+    (account) => account.accountType === "person",
+  );
+  groupAccountList.value = groupAccountStore.groupAccountList;
 });
 
 // 토글 변화에 따라 계좌 목록 상단으로 이동 + 필터 적용
 watch(showGroupAccount, async () => {
-  accountStore.FilterAccount(showGroupAccount.value);
   await nextTick();
   if (scrollContainer.value) {
     scrollContainer.value.scrollTop = 0;
@@ -49,7 +56,7 @@ watch(showGroupAccount, async () => {
 
     <div class="flex flex-col flex-1 overflow-scroll [&::-webkit-scrollbar]:hidden">
       <div
-        v-if="accountList.length === 0"
+        v-if="showGroupAccount ? groupAccountList.length === 0 : accountList.length === 0"
         class="flex flex-col justify-center items-center h-full gap-3"
       >
         <AccountIcon />
@@ -60,7 +67,7 @@ watch(showGroupAccount, async () => {
 
       <div v-else ref="scrollContainer">
         <UnifiedAccountCard
-          v-for="(account, i) in accountList"
+          v-for="(account, i) in showGroupAccount ? groupAccountList : accountList"
           :key="i"
           :account="account"
           :isGroupAccount="showGroupAccount"


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #149

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
예상 작업시간 3시간
실제 작업시간 50분

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
- 계좌 목록 API 연동 하였습니다
- 개인 계좌 목록에 현재 모임계좌 목록도 같이 불러와져 우선 filter 처리 하였습니다 
- API 호출 시점을 처음에는 개인계좌만 호출하고 토글시 모임계좌 목록을 가져오도록 하였습니다

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
- 궁금한점!!! 현재 토글하고 모임계좌 목록이 없때 API 를 호출하게 했는데 이 방법이 좋은지 아니면 처음에 다 호출하는게 좋은지 궁금합니다
 뭔가 나누는게 처을 로드될때 리소스가 줄어들거 같은 느낌적인 느낌이여서 나눴습니다...!

<table>
<tr>
<td>
<img width="377" height="807" alt="image" src="https://github.com/user-attachments/assets/25cbca12-46b7-400c-b154-aec59dc84329" />
</td>
<td>
<img width="401" height="829" alt="image" src="https://github.com/user-attachments/assets/13f3b42c-e3fa-4979-92ec-20c88a47eae8" />
</td>
</tr>
</table>
