### PR TITLE
[FEAT] 환율 정보 목록 API 연동 (#159)

### DIFF
--- a/trippy-client/src/api/exchange.js
+++ b/trippy-client/src/api/exchange.js
@@ -1,0 +1,95 @@
+import api from "./index";
+
+const BASE_URL = `/exchange`;
+
+// 환율 데이터 저장
+export const postExchangeRate = async () => {
+  try {
+    const response = await api.post(BASE_URL);
+
+    return response.data;
+  } catch (error) {
+    console.error("환율 정보 저장 실패", error);
+    throw error;
+  }
+};
+
+// 환율 데이터 목록 조회
+export const getExchangeRate = async () => {
+  try {
+    const response = await api.get(`${BASE_URL}/rates`);
+    // 환율 데이터 목록 받아오기
+    return response.data.data;
+  } catch (error) {
+    console.error("환율 정보 조회 실패", error);
+    throw error;
+  }
+};
+
+// 사용자 계좌 목록 조회
+export const getAccountList = async (userId) => {
+  try {
+    const response = await api.get(`${BASE_URL}/accounts?userId=${userId}`);
+
+    return response.data.data;
+  } catch (error) {
+    console.error("계좌 목록 조회 실패", error);
+    throw error;
+  }
+};
+
+// 환율 및 계좌 잔액(외화/원화) 출력
+export const getRatesAndBalance = async (accoundId, currencyCode, userId) => {
+  try {
+    const response = await api.get(
+      `${BASE_URL}/rate-balance?userId=${userId}&currencyCode=${currencyCode}&accountId=${accoundId}`,
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error("적용할 환율 및 계좌 잔액 조회 실패", error);
+    throw error;
+  }
+};
+
+// 환전 내역 저장
+export const postExchange = async () => {
+  try {
+    const response = await api.post(`${BASE_URL}/exchange`);
+
+    return response.data;
+  } catch (error) {
+    console.error("환전 거래 실패", error);
+    throw error;
+  }
+};
+
+// // -------------------------------------------------------------
+
+// // Get 함수
+// // api.get 함수의 인자로 API 요청 엔드포인트만 전달하면 됩니다.
+// export const getAccount = async (userId) => {
+//   try {
+//     const response = await api.get(`/exchange?userId=${userId}`);
+
+//     return response.data;
+//   } catch (error) {
+//     console.error("계좌 조회 실패", error);
+//     throw error;
+//   }
+// };
+
+// // Post 함수
+// // api.post 함수 인자로 엔드포인트와 전달할 데이터 객체를 넣어주면 됩니다.
+// // accountRequest: API로 넘겨줄 데이터 body
+// // 보통 함수 호출 뷰 코드에서 json 형태로 담아서 객체로 전달합니다.
+// export const postAccount = async (userId, accountRequest) => {
+//   try {
+//     const response = await api.post(/accounts?userId=${userId}, accountRequest);
+
+//     return response.data;
+//   } catch (error) {
+//     console.error("계좌 생성 실패", error);
+//     throw error;
+//   }
+// }

--- a/trippy-client/src/api/exchange.js
+++ b/trippy-client/src/api/exchange.js
@@ -63,33 +63,3 @@ export const postExchange = async () => {
     throw error;
   }
 };
-
-// // -------------------------------------------------------------
-
-// // Get 함수
-// // api.get 함수의 인자로 API 요청 엔드포인트만 전달하면 됩니다.
-// export const getAccount = async (userId) => {
-//   try {
-//     const response = await api.get(`/exchange?userId=${userId}`);
-
-//     return response.data;
-//   } catch (error) {
-//     console.error("계좌 조회 실패", error);
-//     throw error;
-//   }
-// };
-
-// // Post 함수
-// // api.post 함수 인자로 엔드포인트와 전달할 데이터 객체를 넣어주면 됩니다.
-// // accountRequest: API로 넘겨줄 데이터 body
-// // 보통 함수 호출 뷰 코드에서 json 형태로 담아서 객체로 전달합니다.
-// export const postAccount = async (userId, accountRequest) => {
-//   try {
-//     const response = await api.post(/accounts?userId=${userId}, accountRequest);
-
-//     return response.data;
-//   } catch (error) {
-//     console.error("계좌 생성 실패", error);
-//     throw error;
-//   }
-// }

--- a/trippy-client/src/components/account/AccountItem.vue
+++ b/trippy-client/src/components/account/AccountItem.vue
@@ -1,18 +1,22 @@
 <script setup>
 import { defineProps } from "vue";
+import kookminLogo from "@/assets/svg/bankLogo/kookmin.svg?url";
 
 const props = defineProps({
-  data: Object
+  data: Object,
 });
 </script>
 
 <template>
   <div class="flex w-full items-center justify-between p-4 rounded-xl active:bg-blue-100">
     <div class="flex items-center gap-4">
-      <img :src="props.data.logo" class="size-9 bg-gray-100 rounded-full" />
+      <!-- <img :src="props.data.logo" class="size-9 bg-gray-100 rounded-full" /> -->
+      <img :src="kookminLogo" class="size-9 bg-gray-100 rounded-full" />
       <div>
+        <!-- 계좌 테이블 정보에 맞게 컬럼명 변경 필요 -->
         <h3 class="subtitle1">{{ props.data.accountType }}</h3>
-        <p class="body1">{{ props.data.bankName }} {{ props.data.accountNumber }}</p>
+        <!-- <p class="body1">{{ props.data.bankName }} {{ props.data.accountId }}</p> -->
+        <p class="body1">{{ props.data.bankName || "국민은행" }} {{ props.data.accountId }}</p>
       </div>
     </div>
   </div>

--- a/trippy-client/src/stores/exchangeStore.js
+++ b/trippy-client/src/stores/exchangeStore.js
@@ -1,13 +1,20 @@
 // src/stores/exchangeStore.js
 import { defineStore } from "pinia";
 import { ref, computed } from "vue";
-import exchangeRatesRaw from "@/_dummy/exchange_dummy.json";
+// import exchangeRatesRaw from "@/_dummy/exchange_dummy.json";
 import { bankAccounts } from "@/_dummy/bankAccounts_dummy.js";
 import { currencyToCountryMap } from "@/assets/currencyToCountryCodes.js";
+import {
+  postExchangeRate,
+  getExchangeRate,
+  getAccountList,
+  getRatesAndBalance,
+  postExchange,
+} from "@/api/exchange.js";
 
 export const useExchangeStore = defineStore("exchange", () => {
-  const exchangeRates = ref(exchangeRatesRaw);
   const loading = ref(false);
+  const error = ref(null);
 
   // api 연결 시 사용할 함수.
   const formatDate = (date) => {
@@ -17,33 +24,55 @@ export const useExchangeStore = defineStore("exchange", () => {
     return `${yyyy}${mm}${dd}`;
   };
 
-  // 실제 코드 - 매일 날짜 갱신 됨.
-  // const today = new Date();
-  // const yesterday = new Date();
-  // yesterday.setDate(today.getDate() - 1);
+  // 환율 정보 저장
+  const exchangeRates = ref([]);
+  const fetchExchangeRates = async () => {
+    loading.value = true;
+    error.value = null;
+    try {
+      exchangeRates.value = await getExchangeRate();
+    } catch (err) {
+      console.error("환율 정보 가져오기 실패: ", err);
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+  };
 
-  // const todayForm = formatDate(today);
-  // const yesterdayForm = formatDate(yesterday);
+  // 계좌 목록 저장
+  const accountList = ref([]);
+  const fetchAccounts = async () => {
+    loading.value = true;
+    error.value = null;
+    try {
+      const data = await getAccountList();
+      accountList.value = data;
+    } catch (err) {
+      console.error("계좌 목록 가져오기 실패: ", err);
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+  };
 
-  // (개발용) 임시 날짜로 지정해둠
-  const todayForm = "20250722";
-  const yesterdayForm = "20250721";
+  const todayForm = formatDate(new Date());
+  const yesterdayForm = formatDate(new Date(new Date().setDate(new Date().getDate() - 1)));
 
   const todayRates = computed(() =>
-    exchangeRates.value.filter((item) => item.deal_ymd === todayForm),
+    exchangeRates.value.filter((item) => item.exchange_rate_date_yyyymmdd === todayForm),
   );
 
   const yesterdayRates = computed(() =>
-    exchangeRates.value.filter((item) => item.deal_ymd === yesterdayForm),
+    exchangeRates.value.filter((item) => item.exchange_rate_date_yyyymmdd === yesterdayForm),
   );
 
-  const getYesterdayRate = (curUnit) => {
-    const found = yesterdayRates.value.find((item) => item.cur_unit === curUnit);
-    return found?.deal_bas_r || null;
+  const getYesterdayRate = (countryCode) => {
+    const found = yesterdayRates.value.find((item) => item.countryCode === countryCode);
+    return found?.baseExchangeRate || null;
   };
 
-  const getCountryCode = (curUnitRaw) => {
-    const curUnit = curUnitRaw.replace(/\(.*\)/, "").trim();
+  const getCountryCode = (countryCodeRaw) => {
+    const curUnit = countryCodeRaw.replace(/\(.*\)/, "").trim();
     return currencyToCountryMap[curUnit] || "un";
   };
 
@@ -103,5 +132,7 @@ export const useExchangeStore = defineStore("exchange", () => {
     inputForeignAmount,
     inputKrwAmount,
     parseCurrencyCode,
+    fetchExchangeRates,
+    fetchAccounts,
   };
 });

--- a/trippy-client/src/stores/exchangeStore.js
+++ b/trippy-client/src/stores/exchangeStore.js
@@ -24,13 +24,15 @@ export const useExchangeStore = defineStore("exchange", () => {
     return `${yyyy}${mm}${dd}`;
   };
 
-  // 환율 정보 저장
+  // 1. 환율 정보 저장
   const exchangeRates = ref([]);
+
   const fetchExchangeRates = async () => {
     loading.value = true;
     error.value = null;
     try {
-      exchangeRates.value = await getExchangeRate();
+      const data = await getExchangeRate();
+      exchangeRates.value = data;
     } catch (err) {
       console.error("환율 정보 가져오기 실패: ", err);
       error.value = err;
@@ -39,13 +41,13 @@ export const useExchangeStore = defineStore("exchange", () => {
     }
   };
 
-  // 계좌 목록 저장
+  // 2. 계좌 목록 저장
   const accountList = ref([]);
-  const fetchAccounts = async () => {
+  const fetchAccounts = async (userId = 1) => {
     loading.value = true;
     error.value = null;
     try {
-      const data = await getAccountList();
+      const data = await getAccountList(userId); // 유저 1인 경우 가정
       accountList.value = data;
     } catch (err) {
       console.error("계좌 목록 가져오기 실패: ", err);
@@ -53,22 +55,6 @@ export const useExchangeStore = defineStore("exchange", () => {
     } finally {
       loading.value = false;
     }
-  };
-
-  const todayForm = formatDate(new Date());
-  const yesterdayForm = formatDate(new Date(new Date().setDate(new Date().getDate() - 1)));
-
-  const todayRates = computed(() =>
-    exchangeRates.value.filter((item) => item.exchange_rate_date_yyyymmdd === todayForm),
-  );
-
-  const yesterdayRates = computed(() =>
-    exchangeRates.value.filter((item) => item.exchange_rate_date_yyyymmdd === yesterdayForm),
-  );
-
-  const getYesterdayRate = (countryCode) => {
-    const found = yesterdayRates.value.find((item) => item.countryCode === countryCode);
-    return found?.baseExchangeRate || null;
   };
 
   const getCountryCode = (countryCodeRaw) => {
@@ -81,25 +67,23 @@ export const useExchangeStore = defineStore("exchange", () => {
   };
 
   const selectedCurrencyCode = ref(null);
-
   const setSelectedCurrencyCode = (code) => {
     selectedCurrencyCode.value = code;
   };
 
   const selectedAccount = ref(null);
-
   const setSelectedAccount = (account) => {
     selectedAccount.value = account;
   };
 
   const selectedTodayRate = computed(() => {
     if (!selectedCurrencyCode.value) return null;
-    return todayRates.value.find((item) => item.cur_unit === selectedCurrencyCode.value);
+    return exchangeRates.value.find((item) => item.cur_unit === selectedCurrencyCode.value);
   });
 
   const selectedCurrencyName = computed(() => {
     if (!selectedCurrencyCode.value) return null;
-    const match = todayRates.value.find((item) => item.cur_unit === selectedCurrencyCode.value);
+    const match = exchangeRates.value.find((item) => item.cur_unit === selectedCurrencyCode.value);
     return match?.cur_nm || null;
   });
 
@@ -113,12 +97,7 @@ export const useExchangeStore = defineStore("exchange", () => {
 
   return {
     exchangeRates,
-    todayRates,
-    yesterdayRates,
-    getYesterdayRate,
     getCountryCode,
-    todayForm,
-    yesterdayForm,
     loading,
     formatDate,
     selectedCurrencyCode,
@@ -134,5 +113,6 @@ export const useExchangeStore = defineStore("exchange", () => {
     parseCurrencyCode,
     fetchExchangeRates,
     fetchAccounts,
+    accountList,
   };
 });

--- a/trippy-client/src/views/exchange-currency/SelectAccountView.vue
+++ b/trippy-client/src/views/exchange-currency/SelectAccountView.vue
@@ -1,13 +1,14 @@
 <script setup>
-import { bankAccounts } from "@/_dummy/bankAccounts_dummy";
+// import { bankAccounts } from "@/_dummy/bankAccounts_dummy";
 import { useExchangeStore } from "@/stores/exchangeStore";
 import { storeToRefs } from "pinia";
 import { useRouter } from "vue-router";
 import AccountItem from "@/components/account/AccountItem.vue";
 import NextButton from "@/components/common/buttons/NextButton.vue";
+import { onMounted } from "vue";
 
 const accountStore = useExchangeStore();
-const { selectedAccount } = storeToRefs(accountStore);
+const { selectedAccount, accountList } = storeToRefs(accountStore);
 const { setSelectedAccount } = accountStore;
 
 const handleSelect = (account) => {
@@ -18,6 +19,14 @@ const router = useRouter();
 const goToAmountView = () => {
   router.push("/exchange-currency-amount");
 };
+
+onMounted(async () => {
+  try {
+    await accountStore.fetchAccounts();
+  } catch (error) {
+    console.error("계좌 목록 불러오기 실패:", error);
+  }
+});
 </script>
 
 <template>
@@ -26,7 +35,8 @@ const goToAmountView = () => {
       <h2 class="text-center title2 mt-8">환전할 계좌를 선택해주세요</h2>
       <div class="text-center border-b-2 border-gray-300 w-full">
         <p v-if="selectedAccount" class="title4">
-          {{ selectedAccount.bankName }} {{ selectedAccount.accountNumber }}
+          <!-- {{ selectedAccount.bankName }} {{ selectedAccount.accountId }} -->
+          {{ selectedAccount.bankName || "국민은행" }} {{ selectedAccount.accountId }}
         </p>
         <p v-else class="title4 text-gray-400">계좌를 선택해 주세요</p>
       </div>
@@ -35,8 +45,8 @@ const goToAmountView = () => {
     <ul class="w-full overflow-scroll hide-scrollbar pb-12">
       <li
         class="flex cursor-pointer"
-        v-for="account in bankAccounts"
-        :key="account.accountNumber"
+        v-for="account in accountList"
+        :key="account.accountId"
         @click="handleSelect(account)"
       >
         <AccountItem :data="account" />

--- a/trippy-client/src/views/exchange-currency/SelectView.vue
+++ b/trippy-client/src/views/exchange-currency/SelectView.vue
@@ -1,16 +1,15 @@
 <script setup>
-import { ref, computed } from "vue";
+import { ref, onMounted, watch } from "vue";
 import { useExchangeStore } from "@/stores/exchangeStore.js";
 import { Icon } from "@iconify/vue";
 import { useRouter } from "vue-router";
 import NextButton from "@/components/common/buttons/NextButton.vue";
-
-//수출입은행 현재환율api 인증키
-const authkey = "수출입은행 현재환율 api 인증키 부분";
+import { storeToRefs } from "pinia";
 
 const exchangeStore = useExchangeStore();
 
 const { getCountryCode, todayRates, setSelectedCurrencyCode } = exchangeStore;
+const { exchangeRates, loading } = storeToRefs(exchangeStore);
 
 const handleSelect = (code) => {
   setSelectedCurrencyCode(code);
@@ -21,8 +20,18 @@ const goToAccountView = () => {
   router.push("/exchange-currency-account");
 };
 
-const loading = ref(false);
+loading.value = ref(false);
 const error = ref("");
+
+onMounted(async () => {
+  await exchangeStore.fetchExchangeRates();
+});
+watch(
+  () => exchangeStore.exchangeRates,
+  (newVal) => {
+    console.log("환율 데이터 갱신됨:", newVal);
+  },
+);
 </script>
 
 <template>
@@ -37,26 +46,26 @@ const error = ref("");
       class="divide-y divide-gray-200 w-full flex-1 mb-12 overflow-auto hide-scrollbar::-webkit-scrollbar"
     >
       <li
-        v-for="item in todayRates"
-        :key="item.cur_unit"
+        v-for="item in exchangeRates"
+        :key="item.currencyCode"
         class="flex items-center justify-between py-4"
       >
         <div class="flex">
           <span class="w-10">
             <img
-              :src="`https://flagcdn.com/w40/${getCountryCode(item.cur_unit)}.png`"
-              :alt="item.cur_nm"
+              :src="`https://flagcdn.com/w40/${getCountryCode(item.currencyCode)}.png`"
+              :alt="item.currencyName"
               class="w-10 h-7 rounded"
             />
           </span>
-          <span class="font-semibold text-sm text-gray-600 px-4">{{ item.cur_nm }}</span>
+          <span class="font-semibold text-sm text-gray-600 px-4">{{ item.currencyName }}</span>
         </div>
         <div>
-          <button @click="handleSelect(item.cur_unit)" class="p-2">
+          <button @click="handleSelect(item.currencyCode)" class="p-2">
             <Icon
               :class="[
                 'right-6 w-8 h-8',
-                item.cur_unit === exchangeStore.selectedCurrencyCode
+                item.currencyCode === exchangeStore.selectedCurrencyCode
                   ? 'text-blue-400'
                   : 'text-gray-400',
               ]"

--- a/trippy-client/src/views/exchange-rate/ExchangeRateListView.vue
+++ b/trippy-client/src/views/exchange-rate/ExchangeRateListView.vue
@@ -42,7 +42,7 @@ onMounted(async () => {
               <img
                 :src="`https://flagcdn.com/w40/${getCountryCode(item.currencyCode)}.png`"
                 :alt="item.currencyName"
-                class="w-10 h-7 rounded"
+                class="w-10 h-7 rounded object-cover"
               />
             </div>
             <span class="font-semibold text-sm text-gray-900 px-4">
@@ -50,16 +50,16 @@ onMounted(async () => {
             </span>
           </div>
           <div class="flex flex-col text-right text-m">
-            <span class="text-sm font-semibold">{{ item.todayExchangeRate }}원</span>
+            <span class="text-sm font-semibold">{{ item.todayExchangeRate || "-" }}원</span>
             <div
               :class="{
-                'text-red-200': item.upOrDown == '+',
-                'text-blue-400': item.upOrDown == '-',
+                'text-red-200': item.upOrDown === '+',
+                'text-blue-400': item.upOrDown === '-',
               }"
             >
-              <span class="text-xs text-right"> {{ item.upOrDown }}{{ item.changeAmount }}원 </span>
+              <span class="text-xs text-right">{{`${item.upOrDown || ""} ${item.changeAmount || "-"}원`}}</span>
               <span class="text-xs">
-                {{ "(" + item.changePercentage + "%)" }}
+                {{`(${item.changePercentage || "-"}%)`}}
               </span>
             </div>
           </div>

--- a/trippy-client/src/views/exchange-rate/ExchangeRateListView.vue
+++ b/trippy-client/src/views/exchange-rate/ExchangeRateListView.vue
@@ -6,7 +6,7 @@ import NextButton from "@/components/common/buttons/NextButton.vue";
 import { storeToRefs } from "pinia";
 
 const exchangeStore = useExchangeStore();
-const { getYesterdayRate, getCountryCode } = exchangeStore;
+const { getCountryCode } = exchangeStore;
 const { exchangeRates, loading } = storeToRefs(exchangeStore);
 
 const error = ref("");
@@ -19,12 +19,6 @@ const goToExchangeCurrencyView = () => {
 onMounted(async () => {
   await exchangeStore.fetchExchangeRates();
 });
-watch(
-  () => exchangeStore.exchangeRates,
-  (newVal) => {
-    console.log("환율 데이터 갱신됨:", newVal);
-  },
-);
 </script>
 
 <template>
@@ -40,7 +34,7 @@ watch(
       <ul class="divide-y divide-gray-200">
         <li
           v-for="item in exchangeRates"
-          :key="item.currencyCode"
+          :key="item.currencyName"
           class="flex items-center justify-between py-4"
         >
           <div class="flex">
@@ -56,37 +50,16 @@ watch(
             </span>
           </div>
           <div class="flex flex-col text-right text-m">
-            <span class="text-sm font-semibold">{{ item.baseExchangeRate }}원</span>
+            <span class="text-sm font-semibold">{{ item.todayExchangeRate }}원</span>
             <div
               :class="{
-                'text-red-200':
-                  parseFloat(item.baseExchangeRate) -
-                    parseFloat(getYesterdayRate(item.currencyCode)) >=
-                  0,
-                'text-blue-400':
-                  parseFloat(item.baseExchangeRate) -
-                    parseFloat(getYesterdayRate(item.currencyCode)) <
-                  0,
+                'text-red-200': item.upOrDown == '+',
+                'text-blue-400': item.upOrDown == '-',
               }"
             >
-              <span class="text-xs text-right">
-                {{
-                  (
-                    parseFloat(item.baseExchangeRate) -
-                    parseFloat(getYesterdayRate(item.currencyCode))
-                  ).toFixed(2)
-                }}원
-              </span>
+              <span class="text-xs text-right"> {{ item.upOrDown }}{{ item.changeAmount }}원 </span>
               <span class="text-xs">
-                {{
-                  "(" +
-                  (
-                    (parseFloat(item.baseExchangeRate) -
-                      parseFloat(getYesterdayRate(item.currencyCode))) /
-                    parseFloat(getYesterdayRate(item.currencyCode))
-                  ).toFixed(2) +
-                  "%)"
-                }}
+                {{ "(" + item.changePercentage + "%)" }}
               </span>
             </div>
           </div>

--- a/trippy-client/src/views/exchange-rate/ExchangeRateListView.vue
+++ b/trippy-client/src/views/exchange-rate/ExchangeRateListView.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { useExchangeStore } from "@/stores/exchangeStore.js";
-import { ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import NextButton from "@/components/common/buttons/NextButton.vue";
+import { storeToRefs } from "pinia";
 
 const exchangeStore = useExchangeStore();
-const { todayRates, loading, getYesterdayRate, getCountryCode } = exchangeStore;
+const { getYesterdayRate, getCountryCode } = exchangeStore;
+const { exchangeRates, loading } = storeToRefs(exchangeStore);
 
 const error = ref("");
 
@@ -13,6 +15,16 @@ const router = useRouter();
 const goToExchangeCurrencyView = () => {
   router.push("/exchange-currency");
 };
+
+onMounted(async () => {
+  await exchangeStore.fetchExchangeRates();
+});
+watch(
+  () => exchangeStore.exchangeRates,
+  (newVal) => {
+    console.log("환율 데이터 갱신됨:", newVal);
+  },
+);
 </script>
 
 <template>
@@ -27,36 +39,41 @@ const goToExchangeCurrencyView = () => {
     >
       <ul class="divide-y divide-gray-200">
         <li
-          v-for="item in todayRates"
-          :key="item.cur_unit"
+          v-for="item in exchangeRates"
+          :key="item.currencyCode"
           class="flex items-center justify-between py-4"
         >
           <div class="flex">
             <div class="w-10">
               <img
-                :src="`https://flagcdn.com/w40/${getCountryCode(item.cur_unit)}.png`"
-                :alt="item.cur_nm"
+                :src="`https://flagcdn.com/w40/${getCountryCode(item.currencyCode)}.png`"
+                :alt="item.currencyName"
                 class="w-10 h-7 rounded"
               />
             </div>
             <span class="font-semibold text-sm text-gray-900 px-4">
-              {{ item.cur_nm }}
+              {{ item.currencyName }}
             </span>
           </div>
           <div class="flex flex-col text-right text-m">
-            <span class="text-sm font-semibold">{{ item.deal_bas_r }}원</span>
+            <span class="text-sm font-semibold">{{ item.baseExchangeRate }}원</span>
             <div
               :class="{
                 'text-red-200':
-                  parseFloat(item.deal_bas_r) - parseFloat(getYesterdayRate(item.cur_unit)) >= 0,
+                  parseFloat(item.baseExchangeRate) -
+                    parseFloat(getYesterdayRate(item.currencyCode)) >=
+                  0,
                 'text-blue-400':
-                  parseFloat(item.deal_bas_r) - parseFloat(getYesterdayRate(item.cur_unit)) < 0,
+                  parseFloat(item.baseExchangeRate) -
+                    parseFloat(getYesterdayRate(item.currencyCode)) <
+                  0,
               }"
             >
               <span class="text-xs text-right">
                 {{
                   (
-                    parseFloat(item.deal_bas_r) - parseFloat(getYesterdayRate(item.cur_unit))
+                    parseFloat(item.baseExchangeRate) -
+                    parseFloat(getYesterdayRate(item.currencyCode))
                   ).toFixed(2)
                 }}원
               </span>
@@ -64,8 +81,9 @@ const goToExchangeCurrencyView = () => {
                 {{
                   "(" +
                   (
-                    (parseFloat(item.deal_bas_r) - parseFloat(getYesterdayRate(item.cur_unit))) /
-                    parseFloat(getYesterdayRate(item.cur_unit))
+                    (parseFloat(item.baseExchangeRate) -
+                      parseFloat(getYesterdayRate(item.currencyCode))) /
+                    parseFloat(getYesterdayRate(item.currencyCode))
                   ).toFixed(2) +
                   "%)"
                 }}


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #159 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
1일/2일

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
### 환율 정보 목록 API 연동
- 기존에 있던 프론트 코드는 raw data에서 직접 계산하여 환율 정보들을 출력하였지만, 
- 현재는 DB에서 계산된 값으로 불러와 그대로 출력하는 방식으로 개선하였습니다.
- 또한, 통화코드를 정제하여 해당 국가의 국기 이미지를 프론트에서 바로 표시하도록 하였습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
<img width="355" height="920" alt="image" src="https://github.com/user-attachments/assets/62686136-745f-435a-b08a-62b2a701d401" />