### PR TITLE
[FIX] background 잘리는 문제 해결 (#92)

### DIFF
--- a/trippy-client/src/App.vue
+++ b/trippy-client/src/App.vue
@@ -11,7 +11,7 @@ const bgColor = computed(() => route.meta.bgColor || "");
 
 <template>
   <div class="font-sans flex justify-center text-black">
-    <div :class="['relative min-w-screen min-h-screen md:max-w-[365px]', bgColor ? 'bg-white' : 'bg-gray-100']">
+    <div :class="['relative w-screen min-h-screen md:max-w-[365px]', bgColor ? 'bg-white' : 'bg-gray-100']">
       <TopNavigationBar />
 
       <div class="pt-[100px] flex flex-col items-center h-full">

--- a/trippy-client/src/App.vue
+++ b/trippy-client/src/App.vue
@@ -11,7 +11,7 @@ const bgColor = computed(() => route.meta.bgColor || "");
 
 <template>
   <div class="font-sans flex justify-center text-black">
-    <div :class="['relative w-screen h-screen md:max-w-[365px]', bgColor ? 'bg-white' : 'bg-gray-100']">
+    <div :class="['relative min-w-screen min-h-screen md:max-w-[365px]', bgColor ? 'bg-white' : 'bg-gray-100']">
       <TopNavigationBar />
 
       <div class="pt-[100px] flex flex-col items-center h-full">


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #92

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
30M / 10M

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
최상단 레이아웃의 div 높이 값을 다음과 같이 변경했습니다.

기존: h-screen
변경: min-h-screen

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
내용이 길어져도 배경이 잘리지 않습니다!!
(여행로그 뷰 레이아웃 살짝 깨지는 부분은 승원님 API 연동 완료되면 제가 손보겠습니당)

<img width="350" alt="localhost_5173_travel-logs" src="https://github.com/user-attachments/assets/056a1e40-1abe-418e-8d0b-9af0cec9e5d6" />