### PR TITLE
[FEAT] 개인계좌 목록 API 연동 (#222)

### DIFF
--- a/trippy-client/src/components/account/SelectAccountModal.vue
+++ b/trippy-client/src/components/account/SelectAccountModal.vue
@@ -4,12 +4,12 @@ import { useRouter } from "vue-router";
 
 import { Icon } from "@iconify/vue";
 import AccountItem from "@/components/account/AccountItem.vue";
-import { bankAccounts } from "@/_dummy/bankAccounts_dummy.js";
 import { useTransferStore } from "@/stores/transferStore.js";
 
 const props = defineProps({
   modelValue: Boolean,
   accountList: Array,
+  detailAccountId: String,
 });
 
 const router = useRouter();
@@ -19,10 +19,11 @@ const emit = defineEmits(["update:modelValue"]);
 
 const handleSelect = (account) => {
   if (!account) return;
+  console.log(`account:`, account);
 
-  // selectedAccount.value = account;
-  transferStore.setToAccountId(account.accountId); // 계좌 목록 조회 API 연동 후 인자 변경하기
-
+  transferStore.setToAccountId(props.detailAccountId);
+  transferStore.setFromAccountId(account.accountId);
+  transferStore.setBalance(account.balance);
   router.push("/personal-accounts/add");
 };
 

--- a/trippy-client/src/components/account/SelectAccountModal.vue
+++ b/trippy-client/src/components/account/SelectAccountModal.vue
@@ -9,6 +9,7 @@ import { useTransferStore } from "@/stores/transferStore.js";
 
 const props = defineProps({
   modelValue: Boolean,
+  accountList: Array,
 });
 
 const router = useRouter();
@@ -16,14 +17,11 @@ const transferStore = useTransferStore();
 
 const emit = defineEmits(["update:modelValue"]);
 
-const selectedAccount = ref("");
-
 const handleSelect = (account) => {
   if (!account) return;
 
   // selectedAccount.value = account;
-  transferStore.setToAccountId(account.accountNumber); // 계좌 목록 조회 API 연동 후 인자 변경하기
-  console.log(selectedAccount.value); // [임시] 데이터 확인용. 추후 API 연동 시 제거
+  transferStore.setToAccountId(account.accountId); // 계좌 목록 조회 API 연동 후 인자 변경하기
 
   router.push("/personal-accounts/add");
 };
@@ -66,8 +64,8 @@ onUnmounted(() => {
         <ul class="w-full overflow-scroll hide-scrollbar">
           <li
             class="flex cursor-pointer"
-            v-for="account in bankAccounts"
-            :key="account.accountNumber"
+            v-for="account in accountList"
+            :key="account.accountId"
             @click="handleSelect(account)"
           >
             <AccountItem :data="account" />

--- a/trippy-client/src/components/account/group-account/RepresentativeAccountList.vue
+++ b/trippy-client/src/components/account/group-account/RepresentativeAccountList.vue
@@ -2,6 +2,7 @@
 import { Icon } from "@iconify/vue";
 import { defineProps, ref } from "vue";
 import AccountNotice from "./AccountNotice.vue";
+import kookminLogo from "@/assets/svg/bankLogo/kookmin.svg?url";
 
 const props = defineProps({
   accountList: Array,
@@ -30,14 +31,10 @@ const selectAccount = (account) => {
       class="text-center border-[1px] border-gray bg-white rounded-xl h-16 mt-10 flex items-center justify-center gap-8"
     >
       <p
-        class="button1 text-center ml-20 flex-1"
+        class="button1 text-end ml-16 flex-1"
         :class="props.accountBank ? 'text-gray-700' : 'text-gray-400'"
       >
-        {{
-          props.accountBank && props.accountNumber
-            ? `${props.accountBank}   ${props.accountNumber}`
-            : "대표계좌를 선택해 주세요"
-        }}
+        {{ props.accountNumber ? `국민은행 ${props.accountNumber}` : "대표계좌를 선택해 주세요" }}
       </p>
       <Icon
         icon="material-symbols:keyboard-arrow-down-rounded"
@@ -54,12 +51,15 @@ const selectAccount = (account) => {
         <li
           v-for="account in props.accountList"
           :key="account.account"
-          class="hover:bg-gray-100 rounded-xl h-auto cursor-pointer transition-colors duration-200"
+          class="hover:bg-gray-100 rounded-xl h-auto cursor-pointer transition-colors duration-200 mt-2"
           @click="selectAccount(account)"
         >
-          <div class="flex justify-between items-center h-10 mx-3">
-            <p class="body2">{{ account.bankName }}</p>
-            <p class="body2">{{ account.account }}</p>
+          <div class="flex items-center gap-4">
+            <img :src="`${account.logo || kookminLogo}`" class="size-9 bg-gray-100 rounded-full" />
+            <div>
+              <h3 class="subtitle2">{{ account.accountName }}</h3>
+              <p class="body2">{{ account.bankName || "국민은행" }} {{ account.accountId }}</p>
+            </div>
           </div>
         </li>
       </ul>

--- a/trippy-client/src/components/account/group-account/RepresentativeAccountList.vue
+++ b/trippy-client/src/components/account/group-account/RepresentativeAccountList.vue
@@ -7,7 +7,7 @@ import kookminLogo from "@/assets/svg/bankLogo/kookmin.svg?url";
 const props = defineProps({
   accountList: Array,
   accountBank: String,
-  accountNumber: String,
+  accountId: String,
 });
 
 const emits = defineEmits(["selectAccount"]);
@@ -32,9 +32,11 @@ const selectAccount = (account) => {
     >
       <p
         class="button1 text-end ml-16 flex-1"
-        :class="props.accountBank ? 'text-gray-700' : 'text-gray-400'"
+        :class="props.accountId ? 'text-gray-700' : 'text-gray-400'"
       >
-        {{ props.accountNumber ? `국민은행 ${props.accountNumber}` : "대표계좌를 선택해 주세요" }}
+        {{
+          props.accountId ? `${props.accountBank} ${props.accountId}` : "대표계좌를 선택해 주세요"
+        }}
       </p>
       <Icon
         icon="material-symbols:keyboard-arrow-down-rounded"
@@ -51,7 +53,7 @@ const selectAccount = (account) => {
         <li
           v-for="account in props.accountList"
           :key="account.account"
-          class="hover:bg-gray-100 rounded-xl h-auto cursor-pointer transition-colors duration-200 mt-2"
+          class="hover:bg-gray-100 rounded-xl h-auto cursor-pointer transition-colors duration-200 mt-2 ml-1"
           @click="selectAccount(account)"
         >
           <div class="flex items-center gap-4">

--- a/trippy-client/src/components/common/CategoryChip.vue
+++ b/trippy-client/src/components/common/CategoryChip.vue
@@ -9,6 +9,7 @@ const categoryColorMap = {
   CULTURE: "text-[#B726E7] bg-[#F4EAF8]",
   ACCOMMODATION: "text-[#0094AA] bg-[#E3F7F9]",
   OTHER: "text-gray-500 bg-gray-100",
+  INCOME: "text-gray-500 bg-gray-100",
 };
 
 const props = defineProps({
@@ -37,6 +38,7 @@ watch(selected, (v) => {
         <option value="TRANSPORTATION">교통</option>
         <option value="CULTURE">문화</option>
         <option value="ACCOMMODATION">숙박</option>
+        <option value="INCOME">수입</option>
         <option value="OTHER">기타</option>
       </select>
       <Icon

--- a/trippy-client/src/views/group-account/create-account/AgreementStep6View.vue
+++ b/trippy-client/src/views/group-account/create-account/AgreementStep6View.vue
@@ -9,23 +9,18 @@ import { useAccountStore } from "@/stores/accountStore";
 const groupAccountStore = useGroupAccountStore();
 const accountStore = useAccountStore();
 
-const selectAccountNumber = ref("");
+const selectaccountId = ref("");
 const selectAccountBank = ref("");
 
 const accountList = ref([]);
 
 const selectAccount = (account) => {
-  console.log(`account:`, account);
-
-  selectAccountBank.value = account.accountName;
-  selectAccountNumber.value = account.accountId;
-
-  console.log(`selectAccountBank:`, selectAccountBank.value);
-  console.log(`selectAccountNumber:`, selectAccountNumber.value);
+  selectAccountBank.value = "국민은행";
+  selectaccountId.value = account.accountId;
 };
 
 const onClick = async () => {
-  groupAccountStore.setRepresentativeAccount(selectAccountNumber.value, selectAccountBank.value);
+  groupAccountStore.setRepresentativeAccount(selectaccountId.value, selectAccountBank.value);
   await groupAccountStore.createGroupAccount();
   router.push({ name: "group-account-create-complete" });
 };
@@ -50,7 +45,7 @@ onMounted(async () => {
         :accountList="accountList"
         @selectAccount="selectAccount"
         :accountBank="selectAccountBank"
-        :accountNumber="selectAccountNumber"
+        :accountId="selectaccountId"
       />
     </div>
     <NextButton :title="'다음'" :disabled="!selectAccountBank" @click="onClick" />

--- a/trippy-client/src/views/group-account/create-account/AgreementStep6View.vue
+++ b/trippy-client/src/views/group-account/create-account/AgreementStep6View.vue
@@ -1,19 +1,27 @@
 <script setup>
-import { ref } from "vue";
-import accountList from "@/_dummy/accountList_dummy.json";
+import { onMounted, ref } from "vue";
 import RepresentativeAccountList from "@/components/account/group-account/RepresentativeAccountList.vue";
 import { useGroupAccountStore } from "@/stores/groupAccountStore";
 import NextButton from "@/components/common/buttons/NextButton.vue";
 import router from "@/router";
+import { useAccountStore } from "@/stores/accountStore";
 
 const groupAccountStore = useGroupAccountStore();
+const accountStore = useAccountStore();
 
 const selectAccountNumber = ref("");
 const selectAccountBank = ref("");
 
+const accountList = ref([]);
+
 const selectAccount = (account) => {
-  selectAccountBank.value = account.bankName;
-  selectAccountNumber.value = account.account;
+  console.log(`account:`, account);
+
+  selectAccountBank.value = account.accountName;
+  selectAccountNumber.value = account.accountId;
+
+  console.log(`selectAccountBank:`, selectAccountBank.value);
+  console.log(`selectAccountNumber:`, selectAccountNumber.value);
 };
 
 const onClick = async () => {
@@ -21,6 +29,15 @@ const onClick = async () => {
   await groupAccountStore.createGroupAccount();
   router.push({ name: "group-account-create-complete" });
 };
+
+onMounted(async () => {
+  if (accountStore.personalAccountList.length === 0) {
+    await accountStore.getParsonalAccountList();
+  }
+  accountList.value = accountStore.personalAccountList.filter(
+    (account) => account.accountType === "person",
+  );
+});
 </script>
 
 <template>

--- a/trippy-client/src/views/group-account/detail/AccountDetailView.vue
+++ b/trippy-client/src/views/group-account/detail/AccountDetailView.vue
@@ -101,6 +101,10 @@ onMounted(async () => {
       <TransactionItem :transactions="transactions" />
     </div>
 
-    <SelectAccountModal v-model="isModalOpen" :accountList="accountList" />
+    <SelectAccountModal
+      v-model="isModalOpen"
+      :accountList="accountList"
+      :detailAccountId="accountId"
+    />
   </div>
 </template>

--- a/trippy-client/src/views/group-account/detail/AccountDetailView.vue
+++ b/trippy-client/src/views/group-account/detail/AccountDetailView.vue
@@ -8,11 +8,13 @@ import { Icon } from "@iconify/vue";
 import SelectAccountModal from "@/components/account/SelectAccountModal.vue";
 import { useRoute, useRouter } from "vue-router";
 import { numberWithCommas } from "@/assets/utils";
+import { useAccountStore } from "@/stores/accountStore";
 
 const router = useRouter();
 const route = useRoute();
 const filter = ref("ALL");
 const groupAccountStore = useGroupAccountStore();
+const accountStore = useAccountStore();
 
 const accountId = computed(() => String(route.params.accountId));
 
@@ -22,6 +24,8 @@ const transactions = ref([]);
 const role = ref("");
 
 const accountDetail = ref(null);
+
+const accountList = ref([]);
 
 // 거래 구분 필터 handle 함수
 const updateFilter = async (newFilter) => {
@@ -47,6 +51,14 @@ onMounted(async () => {
   balance.value = accountDetail.value.balance;
   transactions.value = accountDetail.value.transactions;
   role.value = accountDetail.value.role;
+
+  if (accountStore.personalAccountList.length === 0) {
+    await accountStore.getParsonalAccountList();
+  }
+
+  accountList.value = accountStore.personalAccountList
+    .filter((account) => account.accountType === "person")
+    .filter((account) => account.accountId !== accountId.value);
 });
 </script>
 
@@ -85,6 +97,6 @@ onMounted(async () => {
       <TransactionItem :transactions="transactions" />
     </div>
 
-    <SelectAccountModal v-model="isModalOpen" />
+    <SelectAccountModal v-model="isModalOpen" :accountList="accountList" />
   </div>
 </template>

--- a/trippy-client/src/views/group-account/join/PickRepresentativeView.vue
+++ b/trippy-client/src/views/group-account/join/PickRepresentativeView.vue
@@ -1,25 +1,37 @@
 <script setup>
-import { ref } from "vue";
-import accountList from "@/_dummy/accountList_dummy.json";
+import { onMounted, ref } from "vue";
 import RepresentativeAccountList from "@/components/account/group-account/RepresentativeAccountList.vue";
 import { useGroupJoinStore } from "@/stores/groupAccountJoinStore";
 import NextButton from "@/components/common/buttons/NextButton.vue";
 import router from "@/router";
+import { useAccountStore } from "@/stores/accountStore";
 
 const groupJoinStore = useGroupJoinStore();
+const accountStore = useAccountStore();
 
-const selectAccountNumber = ref("");
 const selectAccountBank = ref("");
+const selectaccountId = ref("");
 
 const selectAccount = (account) => {
-  selectAccountBank.value = account.bankName;
-  selectAccountNumber.value = account.account;
+  selectAccountBank.value = "국민은행";
+  selectaccountId.value = account.accountId;
 };
 
+const accountList = ref([]);
+
 const onClick = async () => {
-  await groupJoinStore.groupAccountJoin(selectAccountNumber.value);
+  await groupJoinStore.groupAccountJoin(selectaccountId.value);
   router.push({ name: "group-join-complete" });
 };
+
+onMounted(async () => {
+  if (accountStore.personalAccountList.length === 0) {
+    await accountStore.getParsonalAccountList();
+  }
+  accountList.value = accountStore.personalAccountList.filter(
+    (account) => account.accountType === "person",
+  );
+});
 </script>
 
 <template>
@@ -31,11 +43,11 @@ const onClick = async () => {
       <RepresentativeAccountList
         :accountList="accountList"
         @selectAccount="selectAccount"
+        :accountId="selectaccountId"
         :accountBank="selectAccountBank"
-        :accountNumber="selectAccountNumber"
       />
     </div>
-    <NextButton :title="'참여완료하기'" :disabled="!selectAccountBank" @click="onClick" />
+    <NextButton :title="'참여완료하기'" :disabled="!selectaccountId" @click="onClick" />
   </div>
 </template>
 

--- a/trippy-client/src/views/personal-accounts/AccountDetailView.vue
+++ b/trippy-client/src/views/personal-accounts/AccountDetailView.vue
@@ -80,6 +80,10 @@ onMounted(async () => {
       <TransactionFilter :filter="filter" @update:filter="updateFilter" />
       <TransactionItem :transactions="transactions" />
     </div>
-    <SelectAccountModal v-model="isModalOpen" :accountList="accountList" />
+    <SelectAccountModal
+      v-model="isModalOpen"
+      :accountList="accountList"
+      :detailAccountId="accountId"
+    />
   </div>
 </template>

--- a/trippy-client/src/views/personal-accounts/AccountDetailView.vue
+++ b/trippy-client/src/views/personal-accounts/AccountDetailView.vue
@@ -23,6 +23,8 @@ const transactions = ref([]);
 
 const accountId = computed(() => String(route.params.accountId));
 
+const accountList = ref([]);
+
 // 거래 구분 필터 handle 함수
 const updateFilter = async (newFilter) => {
   filter.value = newFilter;
@@ -40,6 +42,14 @@ onMounted(async () => {
   accountName.value = accountDetail.value.accountName;
   balance.value = accountDetail.value.balance;
   transactions.value = accountDetail.value.transactions;
+
+  if (accountStore.personalAccountList.length === 0) {
+    await accountStore.getParsonalAccountList();
+  }
+
+  accountList.value = accountStore.personalAccountList
+    .filter((account) => account.accountType === "person")
+    .filter((account) => account.accountId !== accountId.value);
 });
 </script>
 
@@ -52,7 +62,7 @@ onMounted(async () => {
       </div>
       <div class="flex gap-4">
         <TransferButton type="add" @click="openModal" />
-        <TransferButton type="send" @click="router.push('/personal-accounts/send')"/>
+        <TransferButton type="send" @click="router.push('/personal-accounts/send')" />
       </div>
     </div>
     <div class="bg-gray-100 h-4 mx-[-16px]"></div>
@@ -60,6 +70,6 @@ onMounted(async () => {
       <TransactionFilter :filter="filter" @update:filter="updateFilter" />
       <TransactionItem :transactions="transactions" />
     </div>
-    <SelectAccountModal v-model="isModalOpen" />
+    <SelectAccountModal v-model="isModalOpen" :accountList="accountList" />
   </div>
 </template>

--- a/trippy-client/src/views/personal-accounts/AddMoneyView.vue
+++ b/trippy-client/src/views/personal-accounts/AddMoneyView.vue
@@ -5,11 +5,17 @@ import AmountInputScreen from "@/components/account/AmountInputScreen.vue";
 import PasswordInput from "@/components/common/inputs/PasswordInput.vue";
 import ConfirmTransfer from "@/components/account/ConfirmTransfer.vue";
 import CompleteTransfer from "@/components/account/CompleteTransfer.vue";
+import { useTransferStore } from "@/stores/transferStore";
 
-const views =  [
-  { component: AmountInputScreen, props: { title: "얼마나 채울까요?", type: "add" }},
+const transferStore = useTransferStore();
+
+const views = [
+  {
+    component: AmountInputScreen,
+    props: { title: "얼마나 채울까요?", type: "add", balance: transferStore.balance },
+  },
   { component: PasswordInput },
-  { component: ConfirmTransfer, props: { mode: "add"}},
+  { component: ConfirmTransfer, props: { mode: "add" } },
   { component: CompleteTransfer },
 ];
 const currentIndex = ref(0);
@@ -25,10 +31,6 @@ function goNext() {
 
 <template>
   <main class="w-full bg-white h-full">
-    <component
-      :is="currentView.component"
-      v-bind="currentView.props"
-      @next="goNext"
-    />
+    <component :is="currentView.component" v-bind="currentView.props" @next="goNext" />
   </main>
 </template>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #222 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
예상 작업시간 3시간
실제 작업시간 1시간 30분

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
- 대표계좌 선택 뷰 개인계좌 목록 출력
- 계좌 채우기 버튼 클릭시 개인계좌 목록 출력 (현재 상세조회중인 계좌 제외)
- 계좌 채우기 계좌 선택시 선택된 계좌 store에 저장 및 선택된 계좌 상세조회 API 호출

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
- 계좌에 잘 옮겨지는지 테스트를 하는데 카테고리에 INCOME 이 없어서 추가 했습니다 색상은 일단 기타와 동일 하게 했습니다
- 게좌 목록 API 연결하면서 대표계좌 선택 뷰 계좌 목록 디자인 수정했습니다

<table>
<tr>
<td>
<img width="308" height="671" alt="image" src="https://github.com/user-attachments/assets/184e5c85-3798-484b-906a-2b10cc57aa4e" />
</td>
<td>
<img width="308" height="671" alt="image" src="https://github.com/user-attachments/assets/b24d654c-bc14-4243-ae39-322cfb4134d8" />
</td>
</tr>
<tr>
<td>
<img width="308" height="669" alt="image" src="https://github.com/user-attachments/assets/44df8452-0a7b-446c-952a-01efacae35b1" />
</td>
<td>
<img width="310" height="670" alt="image" src="https://github.com/user-attachments/assets/46d9ca99-06a9-4967-892e-20b105419b75" />
</td>
</tr>
</table>