### PR TITLE
[FEAT] 여행로그 조회 시 멤버 수 0일 경우 1로 표시 (#236)

### DIFF
--- a/trippy-client/src/components/travel-logs/RoundedCard.vue
+++ b/trippy-client/src/components/travel-logs/RoundedCard.vue
@@ -113,7 +113,7 @@ async function generateReport(e) {
         <span class="text-gray-500 flex items-center">
           <Icon v-if="isReportGenerated" icon="ion:person" />
           <Icon v-else icon="ic:sharp-people-alt" />
-          <span class="ml-1">{{ memberCount }}</span>
+          <span class="ml-1">{{ memberCount === 0 ? 1 : memberCount }}</span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #236

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
5분

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
여행로그 멤버 표시할 때 멤버데이터를 account_member 테이블에서 조인해서 가져오는데요
이 테이블에 계좌 정보가 없거나(예성님이 개발한 루트로 계좌 만든게 아닌 경우..)
개인계좌인 경우에 멤버 수 0으로 표시가 되고 있어서

0일 때 무조건 1로 표시하게 바꿨습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요.(구현화면 캡처) -->
